### PR TITLE
refactor(ticketing): request api for message logs

### DIFF
--- a/src/utils/handleTicketDelete.ts
+++ b/src/utils/handleTicketDelete.ts
@@ -154,7 +154,7 @@ export const handleTicketDelete = async (
 
 const fetchMessages = async (
 	channel: TextChannel | ThreadChannel,
-	messages: Message[],
+	messages: Message[] = [],
 	messageId?: Snowflake
 ): Promise<Message[]> => {
 	// limit is 100: https://discord.com/developers/docs/resources/channel#get-channel-messages

--- a/src/utils/handleTicketDelete.ts
+++ b/src/utils/handleTicketDelete.ts
@@ -98,7 +98,7 @@ export const handleTicketDelete = async (
 				if (!logsChannel?.isText()) return;
 				if (!logsChannel.permissionsFor(interaction.guild!.me!).has(['SEND_MESSAGES'])) return;
 
-				const allMessages = await fetchMessages(interaction.channel, []);
+				const allMessages = await fetchMessages(interaction.channel);
 				const messages = allMessages.map((msg) => {
 					if (msg.author.id !== interaction.client.user!.id) {
 						return `${msg.author.tag}: ${msg.content}\n`;


### PR DESCRIPTION
When the bot restarts, the old messages sent in the ticket channels aren't cached, meaning only messages sent after the bot restart will be saved. This fixes the issue by requesting the API for up to 1000 messages in the channel, guaranteeing messages to be in the logs.