### PR TITLE
refactor(suggestions): remove blocked users column

### DIFF
--- a/src/commands/suggestions/suggest-config.ts
+++ b/src/commands/suggestions/suggest-config.ts
@@ -11,27 +11,6 @@ const command: Command = {
 	data: new SlashCommandBuilder()
 		.setName('suggest-config')
 		.setDescription('Edit configuration for suggestions')
-		.addSubcommandGroup((group) =>
-			group
-				.setName('users')
-				.setDescription('Block or unblock a user from using suggestions commands')
-				.addSubcommand((subcommand) =>
-					subcommand
-						.setName('block')
-						.setDescription('Block a user from using suggestions commands')
-						.addUserOption((option) =>
-							option.setName('user').setDescription('The user to block').setRequired(true)
-						)
-				)
-				.addSubcommand((subcommand) =>
-					subcommand
-						.setName('unblock')
-						.setDescription('Unblock a user from using suggestions commands')
-						.addUserOption((option) =>
-							option.setName('user').setDescription('The user to unblock').setRequired(true)
-						)
-				)
-		)
 		.addSubcommand((subcommand) =>
 			subcommand
 				.setName('suggestions-channel')
@@ -85,143 +64,76 @@ const command: Command = {
 				.setTimestamp()
 				.setFooter({ text: `Version ${version}` });
 
-			if (interaction.options.getSubcommandGroup(false) === 'users') {
-				if (!record) {
-					return interaction.reply({
-						content: 'Please specify a suggestions channel first',
-						ephemeral: true
-					});
-				}
+			switch (interaction.options.getSubcommand()) {
+				case 'suggestions-channel': {
+					const channel = interaction.options.getChannel('channel')!;
 
-				switch (interaction.options.getSubcommand()) {
-					case 'block': {
-						const user = interaction.options.getMember('user') as GuildMember;
-						if (user.permissions.has(['MANAGE_CHANNELS'])) {
-							return interaction.reply({
-								content:
-									'You may not block this member from suggesting, they have the manage channels permission',
-								ephemeral: true
-							});
-						}
-
-						// longtext and json difference stuff like bruh
-						let blockedUsers = (
-							typeof record.BlockedUsers === 'string'
-								? JSON.parse(record.BlockedUsers as unknown as string)
-								: record.BlockedUsers
-						) as Tables.Suggestions['BlockedUsers'];
-
-						blockedUsers.push(user.id);
-						blockedUsers = [...new Set(blockedUsers)];
-
-						conn.execute('UPDATE Suggestions SET BlockedUsers = ? WHERE GuildID = ?', [
-							JSON.stringify(blockedUsers),
-							interaction.guildId
-						]);
-						embed.setTitle('Updated Blocked Users');
-						embed.setDescription(
-							`${userMention(user.id)} has been blocked from using suggestion commands`
-						);
-
-						return interaction.reply({ embeds: [embed] });
-					}
-					case 'unblock': {
-						const user = interaction.options.getMember('user') as GuildMember;
-
-						let blockedUsers = (
-							typeof record.BlockedUsers === 'string'
-								? JSON.parse(record.BlockedUsers as unknown as string)
-								: record.BlockedUsers
-						) as Tables.Suggestions['BlockedUsers'];
-
-						blockedUsers = blockedUsers.filter((id) => id !== user.id);
-
-						await conn.execute('UPDATE Suggestions SET BlockedUsers = ? WHERE GuildID = ?', [
-							JSON.stringify(blockedUsers),
-							interaction.guildId
-						]);
-						embed.setTitle('Updated Blocked Users');
-						embed.setDescription(
-							`${userMention(user.id)} has been unblocked from using suggestion commands`
-						);
-
-						return interaction.reply({ embeds: [embed] });
-					}
-					default:
-						break;
-				}
-			} else {
-				switch (interaction.options.getSubcommand()) {
-					case 'suggestions-channel': {
-						const channel = interaction.options.getChannel('channel')!;
-
-						if (!record) {
-							await conn.execute(
-								'INSERT INTO Suggestions (GuildID, SuggestionsChannel) VALUES (?, ?)',
-								[interaction.guildId, channel.id]
-							);
-						} else {
-							await conn.execute(
-								'UPDATE Suggestions SET SuggestionsChannel = ? WHERE GuildID = ?',
-								[channel.id, interaction.guildId]
-							);
-						}
-
-						embed.setTitle('Changed Suggestions Channel');
-						embed.setDescription(
-							`The suggestions channel has been updated to ${channelMention(channel.id)}`
-						);
-
-						return interaction.reply({ embeds: [embed] });
-					}
-					case 'target': {
-						if (!record) {
-							return interaction.reply({
-								content: 'Please specify a suggestions channel first',
-								ephemeral: true
-							});
-						}
-
-						const target = interaction.options.getInteger('amount')!;
-
+					if (!record) {
 						await conn.execute(
-							'UPDATE Suggestions SET Target = ? WHERE GuildID = ?',
-							// TODO: bug: can't update int field where other field is of bigint type
-							// temp fix: convert int field value to string before executing
-							// https://github.com/sidorares/node-mysql2/issues/1483
-							[target.toString(), interaction.guildId]
+							'INSERT INTO Suggestions (GuildID, SuggestionsChannel) VALUES (?, ?)',
+							[interaction.guildId, channel.id]
 						);
-						embed.setTitle('Updated Suggestions Target Value');
-						embed.setDescription(
-							`The amount of upvotes required to be pinned has been updated to ${inlineCode(
-								target.toLocaleString()
-							)}`
-						);
-
-						return interaction.reply({ embeds: [embed] });
-					}
-					case 'reply-embed': {
-						if (!record) {
-							return interaction.reply({
-								content: 'Please specify a suggestions channel first',
-								ephemeral: true
-							});
-						}
-
-						const opposite = !record.ReplyEmbed;
-						await conn.execute('UPDATE Suggestions SET ReplyEmbed = ? WHERE GuildID = ?', [
-							opposite,
+					} else {
+						await conn.execute('UPDATE Suggestions SET SuggestionsChannel = ? WHERE GuildID = ?', [
+							channel.id,
 							interaction.guildId
 						]);
-
-						embed.setTitle('Changed Reply Embed Option');
-						embed.setDescription(`Changed reply embeds to ${opposite ? 'shown' : 'hidden'}`);
-
-						return interaction.reply({ embeds: [embed] });
 					}
-					default:
-						break;
+
+					embed.setTitle('Changed Suggestions Channel');
+					embed.setDescription(
+						`The suggestions channel has been updated to ${channelMention(channel.id)}`
+					);
+
+					return interaction.reply({ embeds: [embed] });
 				}
+				case 'target': {
+					if (!record) {
+						return interaction.reply({
+							content: 'Please specify a suggestions channel first',
+							ephemeral: true
+						});
+					}
+
+					const target = interaction.options.getInteger('amount')!;
+
+					await conn.execute(
+						'UPDATE Suggestions SET Target = ? WHERE GuildID = ?',
+						// TODO: bug: can't update int field where other field is of bigint type
+						// temp fix: convert int field value to string before executing
+						// https://github.com/sidorares/node-mysql2/issues/1483
+						[target.toString(), interaction.guildId]
+					);
+					embed.setTitle('Updated Suggestions Target Value');
+					embed.setDescription(
+						`The amount of upvotes required to be pinned has been updated to ${inlineCode(
+							target.toLocaleString()
+						)}`
+					);
+
+					return interaction.reply({ embeds: [embed] });
+				}
+				case 'reply-embed': {
+					if (!record) {
+						return interaction.reply({
+							content: 'Please specify a suggestions channel first',
+							ephemeral: true
+						});
+					}
+
+					const opposite = !record.ReplyEmbed;
+					await conn.execute('UPDATE Suggestions SET ReplyEmbed = ? WHERE GuildID = ?', [
+						opposite,
+						interaction.guildId
+					]);
+
+					embed.setTitle('Changed Reply Embed Option');
+					embed.setDescription(`Changed reply embeds to ${opposite ? 'shown' : 'hidden'}`);
+
+					return interaction.reply({ embeds: [embed] });
+				}
+				default:
+					break;
 			}
 		} catch (err) {
 			console.error(err);

--- a/src/commands/suggestions/suggest.ts
+++ b/src/commands/suggestions/suggest.ts
@@ -30,19 +30,6 @@ const command: Command = {
 				});
 			}
 
-			const blockedUsers = (
-				typeof record.BlockedUsers === 'string'
-					? JSON.parse(record.BlockedUsers as unknown as string)
-					: record.BlockedUsers
-			) as Tables.Suggestions['BlockedUsers'];
-
-			if (blockedUsers.some((id) => id === interaction.user.id)) {
-				return interaction.reply({
-					content: 'You are blocked from using suggestions commands',
-					ephemeral: true
-				});
-			}
-
 			const title = new MessageActionRow<ModalActionRowComponent>().addComponents(
 				new TextInputComponent()
 					.setCustomId(this.modals!.customIds[1])

--- a/src/other/mysql.ts
+++ b/src/other/mysql.ts
@@ -38,7 +38,6 @@ CREATE TABLE IF NOT EXISTS Suggestions (
   SuggestionsChannel bigint(20) NOT NULL,
   Target smallint NOT NULL DEFAULT 10,
   ReplyEmbed boolean NOT NULL DEFAULT 1,
-  BlockedUsers JSON NOT NULL DEFAULT (JSON_ARRAY()),
   PRIMARY KEY (ID)
 )
 `;

--- a/src/types/Tables.ts
+++ b/src/types/Tables.ts
@@ -33,8 +33,4 @@ export interface Suggestions {
 	SuggestionsChannel: Snowflake;
 	Target: number;
 	ReplyEmbed: boolean;
-	/**
-	 * Might require converting it to an array with JSON.parse() first
-	 */
-	BlockedUsers: Snowflake[];
 }


### PR DESCRIPTION
## Describe the changes you've made

Removed the blocked users column from MySQL. The reason for this is because it's rather unnecessary when you can use command and overwriting permissions instead.

## What type of release does it go under? (select only one)

- [ ] Major release
- [x] Minor release
- [ ] Patch release
