### PR TITLE
fix(ticketing): check for nullable interaction channel

### DIFF
--- a/src/utils/handleTicketDelete.ts
+++ b/src/utils/handleTicketDelete.ts
@@ -17,7 +17,10 @@ export const handleTicketDelete = async (
 	record?: Tables.TicketingManagers
 ) => {
 	try {
-		if (!interaction.channel!.isThread() && !(interaction.channel instanceof TextChannel)) {
+		// users on mobile can still interact with buttons and the archived thread isn't fetched on startup
+		if (!interaction.channel) return;
+
+		if (!interaction.channel.isThread() && !(interaction.channel instanceof TextChannel)) {
 			return interaction.reply({
 				content: 'You must use this command in a support ticket',
 				ephemeral: true


### PR DESCRIPTION
## Describe the changes you've made

Users on mobile can interact with buttons, even if the channel is archived. On the bot's start-up, the archived channel isn't sent to the bot, therefore leaving the channel uncached. The best solution is to do the same as when archiving, don't continue with the rest of the code.

## What type of release does it go under? (select only one)

- [ ] Major release
- [ ] Minor release
- [x] Patch release
