### PR TITLE
revert: docs(website): add NODE_ENV to env file

### DIFF
--- a/apps/website/src/app/docs/self-hosting/page.tsx
+++ b/apps/website/src/app/docs/self-hosting/page.tsx
@@ -24,7 +24,6 @@ const databaseEnvironmentTemplate = `
 `;
 
 const botEnvironmentTemplate = `
-	NODE_ENV="production"
 	DISCORD_APPLICATION_ID=""
 	DISCORD_BOT_TOKEN=""
 	DISCORD_GUILD_ID=""
@@ -105,7 +104,6 @@ export default function Page() {
 				</Paragraph>
 				<CodeBlock clipboardText={botEnvironmentTemplate} fileName=".env.bot.production.local">
 					<span className="flex flex-col">
-						<EnvironmentHighlight name="NODE_ENV" value="production" />
 						<EnvironmentHighlight name="DISCORD_APPLICATION_ID" />
 						<EnvironmentHighlight name="DISCORD_BOT_TOKEN" />
 						<EnvironmentHighlight name="DISCORD_GUILD_ID" />


### PR DESCRIPTION
## Describe the changes you've made

Reverts #359. This is because `NODE_ENV` is set to `production` by default in the `compose.yaml` file.

## What type of release does it go under? (select only one)

- [x] Patch Release