### PR TITLE
fix: move depends_on and specify compose file name for production

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -25,7 +25,9 @@ services:
       context: .
       dockerfile: .devcontainer/bot/Dockerfile
     image: ticketer-bot:development
-
+    depends_on:
+      database:
+        condition: service_healthy
     networks:
       - ticketer-development-database-network
     volumes:

--- a/apps/website/src/app/docs/self-hosting/page.tsx
+++ b/apps/website/src/app/docs/self-hosting/page.tsx
@@ -117,11 +117,12 @@ export default function Page() {
 					Now it is time to run the bot! Run the following command to start the database and bot (this may take some
 					time):
 				</Paragraph>
-				<CodeBlock clipboardText="docker compose --env-file ./.env.database.production.local --env-file ./.env.bot.production.local up -d">
+				<CodeBlock clipboardText="docker compose --env-file ./.env.database.production.local --env-file ./.env.bot.production.local -f compose.yaml up -d">
 					<span>
 						<span className="text-green-500">docker </span>
 						<span>
-							compose --env-file ./.env.database.production.local --env-file ./.env.bot.production.local up -d
+							compose --env-file ./.env.database.production.local --env-file ./.env.bot.production.local -f compose.yaml
+							up -d
 						</span>
 					</span>
 				</CodeBlock>

--- a/base-compose.yaml
+++ b/base-compose.yaml
@@ -31,6 +31,3 @@ services:
       context: .
       dockerfile: ./apps/bot/Dockerfile
     restart: unless-stopped
-    depends_on:
-      database:
-        condition: service_healthy

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ version: '3.8'
 # https://github.com/docker/awesome-compose
 
 # Run this to start the database and bot:
-# docker compose --env-file ./.env.database.production.local --env-file ./.env.bot.production.local up -d
+# docker compose --env-file ./.env.database.production.local --env-file ./.env.bot.production.local -f compose.yaml up -d
 
 # Run this to deploy the commands:
 # docker exec ticketer-bot sh -c "cd /src/apps/bot && pnpm commands:deploy"
@@ -43,6 +43,9 @@ services:
       file: base-compose.yaml
       service: bot
     image: ticketer-bot:3.0.0
+    depends_on:
+      database:
+        condition: service_healthy
     networks:
       - ticketer-database-network
     # Reads the file(s) and exposes the variables when running the container. Undefined files are not allowed.


### PR DESCRIPTION
## Describe the changes you've made

This error came up when trying to deploy to production. This PR fixes the problem, as well as the docker compose command using the wrong compose file in production.

```
service "bot" can't be used with `extends` as it declare `depends_on`
```

## What type of release does it go under? (select only one)

- [x] Patch Release