### PR TITLE
refactor(bot): show enabled/disabled options

### DIFF
--- a/apps/bot/src/commands/staff/configuration-ticket-threads.ts
+++ b/apps/bot/src/commands/staff/configuration-ticket-threads.ts
@@ -951,7 +951,7 @@ export class ComponentInteraction extends Component.Interaction {
 			.where(and(eq(ticketThreadsCategories.id, categoryId), eq(ticketThreadsCategories.guildId, interaction.guildId)));
 
 		if (!row) {
-			return interaction.reply({
+			return interaction.editReply({
 				embeds: [
 					super.userEmbedError(interaction.user).setDescription('No category with the given ID could be found.'),
 				],
@@ -997,7 +997,7 @@ export class ComponentInteraction extends Component.Interaction {
 			.where(and(eq(ticketThreadsCategories.id, categoryId), eq(ticketThreadsCategories.guildId, interaction.guildId)));
 
 		if (!row) {
-			return interaction.reply({
+			return interaction.editReply({
 				embeds: [
 					super.userEmbedError(interaction.user).setDescription('No category with the given ID could be found.'),
 				],

--- a/apps/bot/src/commands/staff/configuration-welcome-farewell.ts
+++ b/apps/bot/src/commands/staff/configuration-welcome-farewell.ts
@@ -367,7 +367,7 @@ export class ComponentInteraction extends Component.Interaction {
 			.userEmbed(user)
 			.setTitle('Updated the Welcome/Farewell Configuration')
 			.setDescription(
-				`${user.toString()} has toggled the ${type} enabled option to ${valueAsBoolean ? 'enabled' : 'disabled'}.`,
+				`${user.toString()} has toggled the ${type} option to ${valueAsBoolean ? 'enabled' : 'disabled'}.`,
 			);
 
 		return interaction.editReply({ embeds: [embed] });

--- a/apps/bot/src/commands/staff/configuration-welcome-farewell.ts
+++ b/apps/bot/src/commands/staff/configuration-welcome-farewell.ts
@@ -344,10 +344,31 @@ export class ComponentInteraction extends Component.Interaction {
 				set: type === 'welcome' ? { welcomeEnabled: not(welcomeEnabled) } : { farewellEnabled: not(farewellEnabled) },
 			});
 
+		const [row] = await database
+			.select({
+				welcomeEnabled: welcomeAndFarewell.welcomeEnabled,
+				farewellEnabled: welcomeAndFarewell.farewellEnabled,
+			})
+			.from(welcomeAndFarewell)
+			.where(eq(welcomeAndFarewell.guildId, interaction.guildId));
+
+		if (!row) {
+			return interaction.editReply({
+				embeds: [
+					super
+						.userEmbedError(interaction.user)
+						.setDescription('No welcome and farewell configuration for the server could be found.'),
+				],
+			});
+		}
+
+		const valueAsBoolean = type === 'welcome' ? row.welcomeEnabled : row.farewellEnabled;
 		const embed = super
 			.userEmbed(user)
 			.setTitle('Updated the Welcome/Farewell Configuration')
-			.setDescription(`${user.toString()} has toggled the ${type} enabled option.`);
+			.setDescription(
+				`${user.toString()} has toggled the ${type} enabled option to ${valueAsBoolean ? 'enabled' : 'disabled'}.`,
+			);
 
 		return interaction.editReply({ embeds: [embed] });
 	}

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -28,6 +28,10 @@ export const ticketThreadsConfigurations = mysqlTable('ticketThreadsConfiguratio
 	activeTickets: tinyint('activeTickets', { unsigned: true }).notNull().default(1),
 });
 
+export const ticketThreadsConfigurationsInsertSchema = createInsertSchema(ticketThreadsConfigurations, {
+	activeTickets: (schema) => schema.activeTickets.int().gte(1).lte(255),
+});
+
 export const ticketThreadsCategories = mysqlTable(
 	'ticketThreadsCategories',
 	{


### PR DESCRIPTION
## Describe the changes you've made

Instead of the bot just saying "toggled the enabled option" it shows whether it's enabled now.

## What type of release does it go under? (select only one)

- [x] Patch Release