### PR TITLE
fix(.github): add specific platforms

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -35,5 +35,5 @@ jobs:
         env:
           DOCKERFILE_ROUTE: ./apps/bot/Dockerfile
         run: |
-          docker build --file ${{ env.DOCKERFILE_ROUTE }} . --no-cache --tag ${{ env.FULL_IMAGE_URL_BOT }}
+          docker build --file ${{ env.DOCKERFILE_ROUTE }} . --no-cache --platform linux/amd64,linux/arm64 --tag ${{ env.FULL_IMAGE_URL_BOT }}
           docker push ${{ env.FULL_IMAGE_URL_BOT }}

--- a/apps/website/src/app/[locale]/docs/self-hosting/page.tsx
+++ b/apps/website/src/app/[locale]/docs/self-hosting/page.tsx
@@ -42,8 +42,10 @@ services:
 
   bot:
     container_name: ticketer-bot
-    # You can change "latest" to any available version such as "3.2.0".
-    image: ghcr.io/carelessinternet/ticketer-bot:latest
+    # You can change to any available version such as "3.2.1".
+    image: ghcr.io/carelessinternet/ticketer-bot:3.2.1
+    # Change the platform to the one on your linux environment (amd64, arm64).
+    platform: linux/arm64
     restart: unless-stopped
     depends_on:
       database:


### PR DESCRIPTION
## Describe the changes you've made

Hopefully this fixes the issue with the bot image not running on a Raspberry Pi 4b.

The errors when trying to run the bot:

`! bot The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested`

`exec /usr/local/bin/docker-entrypoint.sh: exec format error`

## What type of release does it go under? (select only one)

- [x] Patch Release
