### PR TITLE
fix(bot): include tsconfig in dependencies

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -16,13 +16,11 @@
 		"@ticketer/database": "workspace:*",
 		"@ticketer/djs-framework": "workspace:*",
 		"@ticketer/env": "workspace:*",
+		"@ticketer/tsconfig": "workspace:*",
 		"chalk": "^5.6.2",
 		"discord.js": "^14.26.2",
 		"tsx": "^4.21.0",
 		"typesafe-i18n": "^5.27.1",
 		"zod": "^4.3.6"
-	},
-	"devDependencies": {
-		"@ticketer/tsconfig": "workspace:*"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@ticketer/env':
         specifier: workspace:*
         version: link:../../packages/env
+      '@ticketer/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -41,10 +44,6 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-    devDependencies:
-      '@ticketer/tsconfig':
-        specifier: workspace:*
-        version: link:../../packages/tsconfig
 
   apps/website:
     dependencies:


### PR DESCRIPTION
# Describe the changes you've made

Oopsies... This is required for `tsconfig.json` to extend the base configuration properly. The production build/image only installs production dependencies, not dev.

# What type of release does it go under? (select only one)

- [x] Patch Release (e.g. bug fixes and refactors)
